### PR TITLE
Correção de nome de tabela escrito de forma errada

### DIFF
--- a/src/Models/IfoodAuthorizationToken.php
+++ b/src/Models/IfoodAuthorizationToken.php
@@ -8,7 +8,7 @@ use Carbon\Carbon;
 
 class IfoodAuthorizationToken extends Model
 {
-	protected $table = 'ifood_authorizationS';
+	protected $table = 'ifood_authorizations';
 
 	protected $http;
 	protected $grantType;


### PR DESCRIPTION
Ao utilizar o pacote, notei que havia um erro em que o nome da tabela informado no model é diferente do criado pela migration